### PR TITLE
refactor(chat): handle stream by using pipeThough method

### DIFF
--- a/src/lib/clientBuilder/buildApiClient.ts
+++ b/src/lib/clientBuilder/buildApiClient.ts
@@ -5,6 +5,8 @@ import {
   APIClientSchemaValidationErr,
 } from "./error";
 import { env } from "@/config/env";
+import { ParseEventStream } from "../utils/streamUtil/ParseEventStream";
+import { ExtractDataaJSONStream } from "../utils/streamUtil/ExtractDataaJSONStream";
 
 export type Path = `/${string}`;
 type EndpointDefinitionBase<TPath extends Path> = {
@@ -163,7 +165,9 @@ function createEndpointFn<TDef extends EndpointDefinition<Path>>(
           }
         );
       }
-      return res; // Return the raw response for SSE handling
+      return res.body
+        .pipeThrough(new ParseEventStream()) // Return the raw response for SSE handling
+        .pipeThrough(new ExtractDataaJSONStream())
     }
     else {
       // TODO: handle other Content-Type "text/evet-stream"

--- a/src/lib/utils/handleStream.ts
+++ b/src/lib/utils/handleStream.ts
@@ -1,4 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
+import { readStream } from './streamUtil/readStream';
 
 type StreamCallback = (data: any) => void;
 
@@ -9,9 +10,13 @@ interface StreamHandlerOptions {
     onOpen?: () => void; // Callback for handling stream opening
 }
 
-export async function handleStream(
-    response: Response,
-    options: StreamHandlerOptions = {}
+export async function handleStream({
+    stream,
+    options
+}: {
+    stream: ReadableStream<string>
+    options: StreamHandlerOptions
+}
 ) {
     const {
         onMessage, // Function to handle each message
@@ -19,66 +24,15 @@ export async function handleStream(
         onClose = () => console.log('Stream closed'), // Default close handler
         onOpen = () => console.log('Stream opened'), // Default open handler
     } = options;
-
-    if (!response.body) {
-        throw new Error('Response has no body'); // Ensure the response has a body
-    }
-
-    const reader = response.body.getReader(); // Get a reader for the response body
-    const decoder = new TextDecoder(); // Decoder to handle text data
-    let buffer = ''; // Buffer to store incomplete data chunks
-
-    onOpen(); // Trigger the onOpen callback
-
-    try {
-        while (true) {
-            const { done, value } = await reader.read(); // Read the next chunk of data
-
-            if (done) {
-                // If the stream is done, process any remaining data in the buffer
-                if (buffer && onMessage) {
-                    processData(buffer, onMessage);
-                }
-                onClose(); // Trigger the onClose callback
-                break;
-            }
-
-            // Decode the chunk and append it to the buffer
-            const chunk = decoder.decode(value, { stream: true });
-            buffer += chunk;
-
-            // Split the buffer into lines and process complete lines
-            const lines = buffer.split('\n');
-            buffer = lines.pop() || ''; // Keep the last incomplete line in the buffer
-
-            for (const line of lines) {
-                if (line.trim()) {
-                    processData(line, onMessage); // Process each complete line
-                }
-            }
-        }
-    } catch (error) {
-        // Handle any errors during the stream processing
-        onError(error instanceof Error ? error : new Error('Unknown error'));
-        throw error;
-    } finally {
-        reader.releaseLock(); // Release the reader lock when done
-    }
-}
-
-function processData(line: string, onMessage?: StreamCallback) {
-    if (!onMessage) return; // If no onMessage callback is provided, do nothing
-
-    if (line.startsWith('data: ')) {
-        // Process lines that start with 'data: '
-        console.log('line', line);
-
+    return await readStream<string>(stream, (value) => {
         try {
-            const jsonString = line.slice(6); // Remove the 'data: ' prefix
-            const data = JSON.parse(jsonString); // Parse the JSON string
-            onMessage(data); // Trigger the onMessage callback with the parsed data
+            console.log('value', value)
         } catch (error) {
-            console.warn('Failed to parse SSE data:', line); // Log a warning if parsing fails
+            onError(error as Error);
         }
-    }
+    }).catch((error) => {
+        onError(error as Error);
+    }).finally(() => {
+        onClose();
+    });
 }

--- a/src/lib/utils/streamUtil/ExtractDataaJSONStream.ts
+++ b/src/lib/utils/streamUtil/ExtractDataaJSONStream.ts
@@ -1,0 +1,30 @@
+export class ExtractDataaJSONStream<T = unknown> extends TransformStream<string, T> {
+    constructor() {
+        super({
+            start(controller) {
+                // Called when the stream starts
+                console.log("ExtractDataaJSONStream", controller);
+            },
+            transform(eventString, controller) {
+                const chunk = eventString.split("\n")
+                    .filter((line) => line.length)
+                for (const line of chunk) {
+                    if (line.startsWith("data:")) {
+                        const jsonString = line.slice('data:'.length);
+                        try {
+                            const json = JSON.parse(jsonString);
+                            controller.enqueue(json as T);
+                        } catch (error) {
+                            // TODO: handle error
+                            throw new Error(`Failed to parse JSON: ${jsonString}`);
+                        }
+                    }
+                }
+            },
+            flush(controller) {
+                // Called when the stream is closed
+                console.log("ParseEventStream", controller);
+            }
+        });
+    }
+}

--- a/src/lib/utils/streamUtil/ParseEventStream.ts
+++ b/src/lib/utils/streamUtil/ParseEventStream.ts
@@ -1,0 +1,22 @@
+export class ParseEventStream extends TransformStream<Uint8Array, string> {
+    constructor() {
+        super({
+            start(controller) {
+                // Called when the stream starts
+                console.log("ParseEventStream", controller);
+            },
+            transform(chunk, controller) {
+                // This is the data being passed into the transform method.
+                // It could be a Uint8Array (binary data) or a string, depending on the source of the stream.
+                // If it's binary data, decode it to a string
+                const decodedChunk = new TextDecoder('utf8').decode(chunk, { stream: true });
+                console.log('decodedChunk', decodedChunk);
+                controller.enqueue(decodedChunk);
+            },
+            flush(controller) {
+                // Called when the stream is closed
+                console.log("ParseEventStream", controller);
+            }
+        });
+    }
+}

--- a/src/lib/utils/streamUtil/readStream.ts
+++ b/src/lib/utils/streamUtil/readStream.ts
@@ -1,0 +1,20 @@
+export async function readStream<T>(stream: ReadableStream<T>, callback: (value: T) => void) {
+    const reader = stream.getReader();
+    try {
+        while (true) {
+            const { done, value } = await reader.read();
+            if (done) {
+                console.log('Stream finished');
+                break;
+            }
+            try {
+                callback(value);
+            } catch (error) {
+                reader.releaseLock();
+                return Promise.reject(error);
+            }
+        }
+    } catch (error) {
+        throw error;
+    }
+}

--- a/src/pages/chat/index.tsx
+++ b/src/pages/chat/index.tsx
@@ -26,32 +26,41 @@ const ChatScreen = () => {
       // Initialize assistant's response
       // setMessages(prev => [...prev, { role: 'assistant', content: '' }]);
 
-      handleStream(response, {
-        onMessage: (data) => {
-          setMessages(prev => {
-            const _messages = [...prev];
-            const lastMessage = _messages[_messages.length - 1];
-            if (lastMessage.id === data.id) {
-              lastMessage.content += data.content;
-            }
-            else {
-              _messages.push(data)
-            }
-            return _messages;
-          });
-        },
-        onError: (error) => {
-          console.error('Stream error:', error);
-          // Handle error in UI
-        },
-        onClose: () => {
-          setIsStreaming(false);
-          // Handle stream completion
-        },
-        onOpen: () => {
-          console.log('Stream started');
+      // handleStream(response, {
+      //   onMessage: (data) => {
+      //     setMessages(prev => {
+      //       const _messages = [...prev];
+      //       const lastMessage = _messages[_messages.length - 1];
+      //       if (lastMessage.id === data.id) {
+      //         lastMessage.content += data.content;
+      //       }
+      //       else {
+      //         _messages.push(data)
+      //       }
+      //       return _messages;
+      //     });
+      //   },
+      //   onError: (error) => {
+      //     console.error('Stream error:', error);
+      //     // Handle error in UI
+      //   },
+      //   onClose: () => {
+      //     setIsStreaming(false);
+      //     // Handle stream completion
+      //   },
+      //   onOpen: () => {
+      //     console.log('Stream started');
+      //   }
+      // });
+
+      handleStream({
+        stream: response,
+        options: {
+          onMessage: (data) => {
+            console.log('data :>> ', data);
+          }
         }
-      });
+      })
     } catch (error) {
       console.error('Failed to send message:', error);
       setIsStreaming(false);


### PR DESCRIPTION
## What did I do?
This pull request introduces two new `TransformStream` implementations
- `ParseEventStream`
- `ExtractDataaJSONStream`
to handle Server-Sent Events (SSE) and JSON data extraction in a streaming pipeline.

## Key Changes
### `ParseEventStream`
- A `TransformStream` that processes raw Uint8Array chunks from the server.
- Decodes binary data into UTF-8 strings using TextDecoder.
- Prepares the data for further processing by splitting it into manageable chunks.
### ExtractDataaJSONStream
- A `TransformStream` that processes stringified event data.
- Extracts lines starting with `data:` and parses them into JSON objects.
- Enqueues parsed JSON objects for downstream consumption.
- Includes error handling for invalid JSON parsing.
### Integration with `buildApiClient`
- Updated the buildApiClient function to handle text/event-stream responses.
- Piped the response body through `ParseEventStream` and `ExtractDataaJSONStream` to process SSE data into structured JSON objects.